### PR TITLE
Add `void` to create signature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ interface Factory<T> {
   name?: string
   
   /** function that returns a new resource, should call callback with the created resource */
-  create: (callback: (err: Error, client: T) => void) => void
+  create: (callback: (err: Error | void, client: T) => void) => void
   
   /** function that accepts a resource and destroys it */
   destroy: (client: T) => void


### PR DESCRIPTION
When using `strictNullChecks` under TypeScript 1.9, you get an error because `undefined` is not assignable to type `Error`.